### PR TITLE
Add attribute traceId to all pubsub events

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import nock from "nock";
-import { randomUUID } from "crypto";
+import { randomUUID, randomBytes } from "crypto";
 import { pathToRegexp, match } from "path-to-regexp";
 
 const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89abcd][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -190,7 +190,7 @@ async function sendEvent(type, id, event) {
       id,
       updated: new Date(),
     })),
-    attributes: {},
+    attributes: { traceId: randomBytes(16).toString("hex") },
   };
   await pubSubListener(message);
 }

--- a/index.js
+++ b/index.js
@@ -139,7 +139,10 @@ export async function addSlug(slug) {
 
   if (!publishTime) {
     slug.publishTime = new Date().toISOString();
+  } else if (publishTime instanceof Date) {
+    slug.publishTime = publishTime.toISOString();
   }
+
   slugs.push(slug);
 
   const valueContent = contentByType[type][id];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/fake-tool-api",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "type": "module",
   "description": "Mocked Bonnier News tool api, for use in automated tests",
   "main": "index.js",

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -648,11 +648,17 @@ describe("Fake tool api", () => {
       const articleId = randomUUID();
       const slugId1 = randomUUID();
       const slugId2 = randomUUID();
+      const slugId3 = randomUUID();
+      const slugId4 = randomUUID();
       const publishTime1 = "2024-01-01T09:00:00.000Z";
       const publishTime2 = "2024-01-01T11:00:00.000Z";
+      const publishTime3 = new Date("2024-01-01T10:00:00.000Z");
+      const publishTime4 = new Date("2024-01-01T12:00:00.000Z");
 
       await fakeToolApi.addSlug({ id: slugId1, value: articleId, publishTime: publishTime1 });
       await fakeToolApi.addSlug({ id: slugId2, value: articleId, publishTime: publishTime2 });
+      await fakeToolApi.addSlug({ id: slugId3, value: articleId, publishTime: publishTime3 });
+      await fakeToolApi.addSlug({ id: slugId4, value: articleId, publishTime: publishTime4 });
 
       const res = await fetch(`${baseUrl}/slug/byValue/${articleId}`);
       expect(res.status).to.equal(200);
@@ -661,9 +667,19 @@ describe("Fake tool api", () => {
       expect(data).to.deep.equal({
         slugs: [
           {
+            id: slugId4,
+            value: articleId,
+            publishTime: publishTime4.toISOString(),
+          },
+          {
             id: slugId2,
             value: articleId,
             publishTime: publishTime2,
+          },
+          {
+            id: slugId3,
+            value: articleId,
+            publishTime: publishTime3.toISOString(),
           },
           {
             id: slugId1,


### PR DESCRIPTION
Mimic production Tool API by sending `traceId` as a pubsub attribute.

Some tests in IA calls `addSlug` with a `Date` in `publishTime`. This PR always converts them into strings on creation.

## Why?
I would like to forward trace info in IA's pubsub as well and need this to write correct tests there.