### PR TITLE
Fix bugs regarding adding slugs

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,8 +36,16 @@ const routes = {
   }),
 };
 
-let types, contentByType, workingCopiesByType = {}, userSettings, slugs = [], versionsMeta = {}, versions = {}, referencedBy = {}, baseUrl;
-let interceptor = () => { };
+let types;
+let contentByType;
+let workingCopiesByType = {};
+let userSettings;
+let slugs = [];
+let versionsMeta = {};
+let versions = {};
+let referencedBy = {};
+let baseUrl;
+let interceptor = () => {};
 
 function buildRoute(route, handlers) {
   return {
@@ -83,7 +91,7 @@ export function intercept(interceptFn) {
   interceptor = interceptFn || (() => { });
 }
 
-// resets content an initialize basic types ()
+// Resets content and initializes basic types
 export function resetContent() {
   initBasetypes();
   slugs = [];
@@ -126,12 +134,14 @@ export async function removeContent(type, id) {
 }
 
 export async function addSlug(slug) {
-  if (!slug.publishTime) {
-    slug.publishTime = new Date();
+  const { valueType, value: id, publishTime } = slug;
+  const type = valueType || "article";
+
+  if (!publishTime) {
+    slug.publishTime = new Date().toISOString();
   }
   slugs.push(slug);
 
-  const { valueType: type, value: id } = slug;
   const valueContent = contentByType[type][id];
   if (shouldSendPublishingEventMessage(types[type], valueContent)) {
     await sendEvent(type, id, "published");
@@ -144,6 +154,7 @@ export function removeSlug(slug) {
     && p.value === slug.value
     && p.path === slug.path));
 }
+
 export function addType(type, allowRedefine = false) {
   if (!type.properties) {
     type.properties = {};
@@ -505,23 +516,27 @@ function list(req) {
       return excludeTypes.indexOf(item.type) === -1;
     });
   }
+
   const filterTypes = req.searchParams.getAll("type");
   if (filterTypes.length > 0) {
     items = items.filter((item) => filterTypes.includes(item.type));
   }
 
   const orgLength = items.length;
-
   let responseItems = items;
+
   const from = req.searchParams.get("cursor");
   if (from) {
     items = items.slice(parseInt(from));
   }
+
   const size = req.searchParams.get("size");
   if (size) {
     responseItems = items.slice(0, parseInt(size));
   }
-  let nextCursor, nextUrl;
+
+  let nextCursor;
+  let nextUrl;
   if (responseItems.length < items.length) {
     nextCursor = orgLength - (items.length - responseItems.length);
     const nextUrlObj = new URL(req.url, baseUrl);
@@ -529,11 +544,13 @@ function list(req) {
     nextUrl = nextUrlObj.toString();
 
   }
+
   responseItems = JSON.parse(JSON.stringify(responseItems));
   responseItems.forEach((item) => {
     item.sequenceNumber = item.content.sequenceNumber;
     delete item.content.sequenceNumber;
   });
+
   const responseBody = { items: responseItems, nextCursor, next: nextUrl };
   return [ 200, responseBody ];
 }
@@ -578,7 +595,7 @@ async function requestSlug(req) {
 }
 
 function shouldSendPublishingEventMessage(typeDefinition, valueContent) {
-  if (!valueContent) return false;
+  if (!typeDefinition || !valueContent || !valueContent.attributes) return false;
   if (typeDefinition.hasPublishedState && valueContent.publishedState !== "PUBLISHED") return false;
   if (valueContent.attributes.firstPublishTime && new Date(valueContent.attributes.firstPublishTime) > new Date()) return false;
 
@@ -635,19 +652,23 @@ function slugsList(req) {
   if (channel) {
     items = items.filter((item) => item.channel === channel);
   }
+
   const path = req.searchParams.get("path");
   if (path) {
     items = items.filter((item) => item.path === path);
   }
+
   const valueType = req.searchParams.get("valueType");
   if (valueType) {
     items = items.filter((item) => item.valueType === valueType);
   }
+
   const value = req.searchParams.get("value");
   if (value) {
     items = items.filter((item) => item.value === value);
   }
-  const responseBody = { items/* , next*/ };
+
+  const responseBody = { items };
   return [ 200, responseBody ];
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bonniernews/fake-tool-api",
-  "version": "1.5.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bonniernews/fake-tool-api",
-      "version": "1.5.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
         "nock": "^13.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/fake-tool-api",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "type": "module",
   "description": "Mocked Bonnier News tool api, for use in automated tests",
   "main": "index.js",
@@ -18,7 +18,9 @@
     "lint": "eslint . --cache"
   },
   "license": "MIT",
-  "files": ["index.js"],
+  "files": [
+    "index.js"
+  ],
   "devDependencies": {
     "@bonniernews/eslint-config": "^2.0.2",
     "chai": "^5.1.0",

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -6,8 +6,9 @@ import * as fakeToolApi from "../index.js";
 
 const baseUrl = "https://fake-tool-api-test";
 describe("Fake tool api", () => {
-
   const events = [];
+  const id = randomUUID();
+
   beforeEach(() => {
     fakeToolApi.init(baseUrl, (msg) => {
       events.push(JSON.parse(msg.data));
@@ -15,7 +16,6 @@ describe("Fake tool api", () => {
     fakeToolApi.addType({ name: "article" }, true);
     events.length = 0;
   });
-  const id = randomUUID();
 
   describe("working-copy", () => {
     it("should support PUT:ing working copy", async () => {
@@ -133,6 +133,52 @@ describe("Fake tool api", () => {
       const res = await fetch(`${baseUrl}/types`);
       const types = await res.json();
       expect(types[0].properties.attributes.properties).to.have.property("cool");
+    });
+  });
+
+  describe("#addSlug", () => {
+    it("should set default publishTime, if not given", async () => {
+      await fakeToolApi.addSlug({});
+
+      const slugs = fakeToolApi.peekSlugs();
+      expect(slugs).to.have.length(1);
+      expect(slugs[0]).to.have.property("publishTime");
+      expect(slugs[0].publishTime).to.be.a("string");
+    });
+  });
+
+  describe("#removeSlug", () => {
+    const channel = "channel";
+    beforeEach(() => {
+      [ 1, 2, 3 ].forEach(async (i) => {
+        await fakeToolApi.addSlug({
+          channel,
+          path: `/path-${i}`,
+          value: `value-${i}`,
+
+        });
+      });
+    });
+
+    it("should remove the given slug", () => {
+      const originalSlugs = fakeToolApi.peekSlugs();
+      expect(originalSlugs).to.have.length(3);
+
+      fakeToolApi.removeSlug({ channel, path: "/path-2", value: "value-2" });
+
+      const slugs = fakeToolApi.peekSlugs();
+      expect(slugs).to.have.length(2);
+      expect(slugs.find((slug) => slug.path === "/path-2")).to.not.exist;
+    });
+
+    it("should not remove non-existing slug", () => {
+      const originalSlugs = fakeToolApi.peekSlugs();
+      expect(originalSlugs).to.have.length(3);
+
+      fakeToolApi.removeSlug({ channel, path: "/non-existing-path", value: "value-2" });
+
+      const slugs = fakeToolApi.peekSlugs();
+      expect(slugs).to.have.length(3);
     });
   });
 
@@ -576,6 +622,64 @@ describe("Fake tool api", () => {
       });
       expect(response.status).to.eql(200);
       expect(events).to.have.length(0);
+    });
+  });
+
+  describe("GET /slug", () => {
+    it("should return existing slug", async () => {
+      await fakeToolApi.addSlug({ id });
+
+      const res = await fetch(`${baseUrl}/slug/${id}`);
+      expect(res.status).to.equal(200);
+
+      const data = await res.json();
+      expect(data).to.have.property("id", id);
+      expect(data).to.have.property("publishTime");
+    });
+
+    it("should return 404 for non-existing slug", async () => {
+      const res = await fetch(`${baseUrl}/slug/${id}`);
+      expect(res.status).to.equal(404);
+    });
+  });
+
+  describe("GET /slug/byValue", () => {
+    it("should return existing slugs, sorted by publishTime", async () => {
+      const articleId = randomUUID();
+      const slugId1 = randomUUID();
+      const slugId2 = randomUUID();
+      const publishTime1 = "2024-01-01T09:00:00.000Z";
+      const publishTime2 = "2024-01-01T11:00:00.000Z";
+
+      await fakeToolApi.addSlug({ id: slugId1, value: articleId, publishTime: publishTime1 });
+      await fakeToolApi.addSlug({ id: slugId2, value: articleId, publishTime: publishTime2 });
+
+      const res = await fetch(`${baseUrl}/slug/byValue/${articleId}`);
+      expect(res.status).to.equal(200);
+
+      const data = await res.json();
+      expect(data).to.deep.equal({
+        slugs: [
+          {
+            id: slugId2,
+            value: articleId,
+            publishTime: publishTime2,
+          },
+          {
+            id: slugId1,
+            value: articleId,
+            publishTime: publishTime1,
+          },
+        ],
+      });
+    });
+
+    it("should return the empty array for non-existing article GUID", async () => {
+      const res = await fetch(`${baseUrl}/slug/byValue/${id}`);
+      expect(res.status).to.equal(200);
+
+      const data = await res.json();
+      expect(data).to.deep.equal({ slugs: [] });
     });
   });
 


### PR DESCRIPTION
If `publishTime` was not given, it was set to a `Date`. This caused a
run-time error when sorting in `filterSlugsByValue`, since it presumed
that the values were strings (using `String.localCompare`);

There was also a run-time error when omitting the property `valueType`
from the mocked slug body. The value now defaults to `"article"`.

Tests are added for most of the slug-related functionality.

Some "linting" and formatting are also added, for readability.
